### PR TITLE
Import auto-scroll update from Icon-O-Matic that use system auto-scroll

### DIFF
--- a/WonderBrush/src/gui/listviews/CanvasListView.cpp
+++ b/WonderBrush/src/gui/listviews/CanvasListView.cpp
@@ -121,7 +121,7 @@ void
 CanvasListView::SetDropTargetRect(const BMessage* message, BPoint where)
 {
 	if (message->what == B_SIMPLE_DATA) {
-		_SetDropAnticipationRect(Bounds());
+		SetDropRect(Bounds());
 	} else {
 		SimpleListView::SetDropTargetRect(message, where);
 	}

--- a/WonderBrush/src/gui/listviews/HistoryListView.cpp
+++ b/WonderBrush/src/gui/listviews/HistoryListView.cpp
@@ -47,7 +47,7 @@ enum {
 
 // PaintObjectItem
 void
-ObjectItemPainter::PaintObjectItem(BView* owner, BRect itemFrame, uint32 flags)
+ObjectItemPainter::PaintObjectItem(BView* owner, BRect itemFrame, uint32)
 {
 	owner->SetHighColor( 0, 0, 0, 255 );
 	font_height fh;
@@ -95,14 +95,14 @@ HistoryItem::Update(BView* owner, const BFont* font)
 
 // Draw
 void
-HistoryItem::Draw(BView* owner, BRect frame, uint32 flags)
+HistoryItem::DrawItem(BView* owner, BRect frame, bool even)
 {
 	if (fPainter) {
-		SimpleItem::DrawBackground(owner, frame, flags);
+		SimpleItem::DrawBackground(owner, frame, even);
 		// additional grafics to distinguish tools
-		fPainter->PaintObjectItem(owner, frame, flags);
+		fPainter->PaintObjectItem(owner, frame, 0);
 	} else {
-		SimpleItem::Draw(owner, frame, flags);
+		SimpleItem::DrawItem(owner, frame, even);
 	}
 }
 

--- a/WonderBrush/src/gui/listviews/HistoryListView.h
+++ b/WonderBrush/src/gui/listviews/HistoryListView.h
@@ -51,8 +51,8 @@ class HistoryItem : public SimpleItem {
 
 
 							// SimpleItem
-		virtual	void		Draw(BView* owner, BRect frame,
-								 uint32 flags);
+		virtual	void		DrawItem(BView* owner, BRect frame,
+								 bool even = false);
 
 							// HistoryItem
 				void		SetPainter(ObjectItemPainter* painter);

--- a/WonderBrush/src/gui/listviews/LayersListView.cpp
+++ b/WonderBrush/src/gui/listviews/LayersListView.cpp
@@ -108,10 +108,10 @@ LayerItem::Update(BView* owner, const BFont* font)
 
 // Draw
 void
-LayerItem::Draw(BView* owner, BRect frame, uint32 flags)
+LayerItem::DrawItem(BView* owner, BRect frame, bool even)
 {
 	if (Layer* layer = fParent->LayerFor(this)) {
-		DrawBackground(owner, frame, flags);
+		DrawBackground(owner, frame, even);
 		BRect r(frame);
 		BRect iconRect(frame);
 		GetIconRect(iconRect);
@@ -151,9 +151,9 @@ LayerItem::Draw(BView* owner, BRect frame, uint32 flags)
 		r.left = iconRect.right + 2.0;
 		r.right = frame.right;
 		owner->SetDrawingMode(B_OP_COPY);
-		SimpleItem::Draw(owner, r, flags);
+		SimpleItem::DrawItem(owner, r, even);
 	} else
-		SimpleItem::Draw(owner, frame, flags);
+		SimpleItem::DrawItem(owner, frame, even);
 }
 
 // GetIconRect
@@ -602,7 +602,7 @@ LayersListView::SetDropTargetRect(const BMessage* message, BPoint where)
 					r = ItemFrame(index - 1);
 					r.OffsetBy(0.0, r.Height() + 1);
 				}
-				_SetDropAnticipationRect(r);
+				SetDropRect(r);
 				fDropIndex = index;
 
 				if (message->what != B_PASTE) {

--- a/WonderBrush/src/gui/listviews/LayersListView.h
+++ b/WonderBrush/src/gui/listviews/LayersListView.h
@@ -28,8 +28,8 @@ class LayerItem : public SimpleItem {
 		virtual	void		Update(BView* owner, const BFont* font);
 
 							// SimpleItem
-		virtual	void		Draw(BView* owner, BRect frame,
-								 uint32 flags);
+		virtual	void		DrawItem(BView* owner, BRect frame,
+								 bool even = false);
 
 				void		GetIconRect(BRect& itemFrame) const;
 

--- a/WonderBrush/src/gui/listviews/ListViews.h
+++ b/WonderBrush/src/gui/listviews/ListViews.h
@@ -10,22 +10,17 @@
 #include <layout.h>
 
 #include "MouseWheelFilter.h"
-
-enum
-{
-	FLAGS_NONE			= 0x00,
-	FLAGS_TINTED_LINE	= 0x01,
-	FLAGS_FOCUSED		= 0x02,
-};
+#include "Observer.h"
 
 // portion of the listviews height that triggers autoscrolling
 // when the mouse is over it with a dragmessage
 #define SCROLL_AREA			0.1
 
-class BMessageRunner;
 class BMessageFilter;
-class InterfaceWindow;
+class BMessageRunner;
 class BScrollView;
+class Selectable;
+class Selection;
 
 // SimpleItem
 class SimpleItem : public BStringItem
@@ -34,62 +29,43 @@ class SimpleItem : public BStringItem
 							SimpleItem(const char* name);
 		virtual				~SimpleItem();
 
-		virtual	void		Draw(BView* owner, BRect frame,
-								 uint32 flags);
-		virtual	void		DrawBackground(BView* owner, BRect frame,
-								  uint32 flags);
-
-							// let the item know what's going on
-/*		virtual	void		AttachedToListView(SimpleListView* owner);
-		virtual	void		DetachedFromListView(SimpleListView* owner);
-
-		virtual	void		SetItemFrame(BRect frame);*/
-
- private:
-
+		virtual	void		DrawItem(BView*, BRect, bool even = false);
+		virtual	void		DrawBackground(BView*, BRect, bool even);
 };
 
-// DragSortableListView
-class DragSortableListView : public MouseWheelTarget,
-							 public BListView {
+
+class DragSortableListView : public BListView,
+	public MouseWheelTarget {
  public:
-							DragSortableListView( BRect frame,
-												  const char* name,
-												  list_view_type type
-														= B_SINGLE_SELECTION_LIST,
-												  uint32 resizingMode
-														= B_FOLLOW_LEFT
-														  | B_FOLLOW_TOP,
-												  uint32 flags
-														= B_WILL_DRAW
-														  | B_NAVIGABLE
-														  | B_FRAME_EVENTS );
+							DragSortableListView(BRect frame,
+								const char* name,
+								list_view_type type = B_SINGLE_SELECTION_LIST,
+								uint32 resizingMode
+									= B_FOLLOW_LEFT | B_FOLLOW_TOP,
+								uint32 flags = B_WILL_DRAW | B_NAVIGABLE
+									| B_FRAME_EVENTS);
 	virtual					~DragSortableListView();
 
-							// BListView
+	// BListView interface
 	virtual	void			AttachedToWindow();
 	virtual	void			DetachedFromWindow();
 	virtual	void			FrameResized(float width, float height);
 //	virtual	void			MakeFocus(bool focused);
-	virtual	void			Draw( BRect updateRect );
-	virtual	void			ScrollTo(BPoint where);
-	virtual	void			TargetedByScrollView(BScrollView* scrollView);
-	virtual	bool			InitiateDrag( BPoint point, int32 index,
-										  bool wasSelected );
-	virtual void			MessageReceived( BMessage* message );
-	virtual	void			KeyDown( const char* bytes, int32 numBytes );
-	virtual	void			MouseDown( BPoint where );
-	virtual void			MouseMoved( BPoint where, uint32 transit,
-										const BMessage* dragMessage );
-	virtual void			MouseUp( BPoint where );
-	virtual	void			WindowActivated( bool active );
-	virtual void			DrawItem( BListItem *item, BRect itemFrame,
-									  bool complete = false);
+	virtual	void			TargetedByScrollView(BScrollView*);
+	virtual void			MessageReceived(BMessage* message);
+	virtual	void			KeyDown(const char* bytes, int32 numBytes);
+	virtual	void			MouseDown(BPoint where);
+	virtual void			MouseMoved(BPoint where, uint32, const BMessage*);
+	virtual void			MouseUp(BPoint where);
+	virtual	void			WindowActivated(bool active);
 
-							// MouseWheelTarget
+	// MouseWheelTarget interface
 	virtual	bool			MouseWheelChanged(float x, float y);
 
-							// DragSortableListView
+	// Observer interface (watching Selection)
+	virtual	void			ObjectChanged(const Observable* object);
+
+	// DragSortableListView
 	virtual	void			SetDragCommand(uint32 command);
 	virtual	void			ModifiersChanged();	// called by window
 	virtual	void			DoubleClicked(int32 index) {}
@@ -97,32 +73,39 @@ class DragSortableListView : public MouseWheelTarget,
 	virtual	void			SetItemFocused(int32 index);
 
 	virtual	bool			AcceptDragMessage(const BMessage* message) const;
+	virtual	bool			HandleDropMessage(const BMessage* message,
+								int32 dropIndex);
 	virtual	void			SetDropTargetRect(const BMessage* message,
-											  BPoint where);
+								BPoint where);
 
-							// autoscrolling
-			void			SetAutoScrolling(bool enable);
 			bool			DoesAutoScrolling() const;
 			BScrollView*	ScrollView() const
 								{ return fScrollView; }
-			void			ScrollTo(int32 index);
 
 	virtual	void			MoveItems(BList& items, int32 toIndex);
 	virtual	void			CopyItems(BList& items, int32 toIndex);
 	virtual	void			RemoveItemList(BList& indices);
 			void			RemoveSelected(); // uses RemoveItemList()
-			int32			CountSelectedItems() const;
-			void			SelectAll();
 	virtual	bool			DeleteItem(int32 index);
 
+							// selection
+			void			SetSelection(Selection* selection);
+
+	virtual	int32			IndexOfSelectable(Selectable* selectable) const;
+	virtual	Selectable*		SelectableFor(BListItem* item) const;
+
+			void			SetDeselectAllInGlobalSelection(bool deselect);
+
+			void			SelectAll();
+			int32			CountSelectedItems() const;
+	virtual	void			SelectionChanged();
+
 	virtual	BListItem*		CloneItem(int32 atIndex) const = 0;
-	virtual	void			DrawListItem(BView* owner, int32 index,
-										 BRect itemFrame) const = 0;
 	virtual	void			MakeDragMessage(BMessage* message) const = 0;
 
- private:
-			void			_RemoveDropAnticipationRect();
-			void			_SetDragMessage(const BMessage* message);
+ protected:
+			void			InvalidateDropRect();
+			void			SetDragMessage(const BMessage* message);
 
 	BRect					fDropRect;
 	BMessage				fDragMessageCopy;
@@ -131,31 +114,32 @@ class DragSortableListView : public MouseWheelTarget,
 	BPoint					fLastMousePos;
 
  protected:
-			void			_SetDropAnticipationRect(BRect r);
-			void			_SetDropIndex(int32 index);
+			void			SetDropRect(BRect rect);
+			void			SetDropIndex(int32 index);
 
 	int32					fDropIndex;
 	BListItem*				fLastClickedItem;
 	BScrollView*			fScrollView;
 	uint32					fDragCommand;
 	int32					fFocusedIndex;
+
+	Selection*				fSelection;
+	bool					fSyncingToSelection;
+	bool					fModifyingSelection;
 };
 
 // SimpleListView
 class SimpleListView : public MView, public DragSortableListView {
  public:
-							SimpleListView( BRect frame,
-											BMessage* selectionChangeMessage = NULL );
-							SimpleListView( BRect frame,
-											const char* name,
-											BMessage* selectionChangeMessage = NULL,
-											list_view_type type
-												= B_MULTIPLE_SELECTION_LIST,
-											uint32 resizingMode
-												= B_FOLLOW_ALL_SIDES,
-											uint32 flags
-												= B_WILL_DRAW | B_NAVIGABLE
-												  | B_FRAME_EVENTS | B_FULL_UPDATE_ON_RESIZE );
+							SimpleListView(BRect frame,
+								BMessage* selectionChanged = NULL);
+							SimpleListView(BRect frame, const char* name,
+								BMessage* selectionChanged = NULL,
+								list_view_type type
+									= B_MULTIPLE_SELECTION_LIST,
+								uint32 resizingMode = B_FOLLOW_ALL_SIDES,
+								uint32 flags = B_WILL_DRAW | B_NAVIGABLE
+									| B_FRAME_EVENTS | B_FULL_UPDATE_ON_RESIZE);
 							~SimpleListView();
 
 							// MView
@@ -163,13 +147,23 @@ class SimpleListView : public MView, public DragSortableListView {
 	virtual	BRect			layout(BRect frame);
 
 							// BListView
+	virtual	void			DetachedFromWindow();
+	virtual	void			Draw(BRect updateRect);
+	virtual	bool			InitiateDrag(BPoint, int32, bool);
 	virtual void			MessageReceived(BMessage* message);
-	virtual	void			SelectionChanged();
 
 	virtual	BListItem*		CloneItem(int32 atIndex) const;
-	virtual	void			DrawListItem(BView* owner, int32 index,
-										 BRect itemFrame) const;
+
+	virtual	status_t		ArchiveSelection(BMessage*, bool = true) const;
+	virtual	bool			InstantiateSelection(const BMessage*, int32);
+
 	virtual	void			MakeDragMessage(BMessage* message) const;
+	virtual	bool			HandleDropMessage(const BMessage* message,
+								int32 dropIndex);
+			bool			HandlePaste(const BMessage* archive);
+
+ protected:
+			void			_MakeEmpty();
 
  private:
 
@@ -177,3 +171,4 @@ class SimpleListView : public MView, public DragSortableListView {
 };
 
 #endif // LIST_VIEWS_H
+

--- a/WonderBrush/src/gui/listviews/Observer.cpp
+++ b/WonderBrush/src/gui/listviews/Observer.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2006, Haiku.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ */
+
+#include "Observer.h"
+
+Observer::Observer()
+{
+}
+
+Observer::~Observer()
+{
+}
+

--- a/WonderBrush/src/gui/listviews/Observer.h
+++ b/WonderBrush/src/gui/listviews/Observer.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2006, Haiku.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ */
+
+#ifndef OBSERVER_H
+#define OBSERVER_H
+
+#include <SupportDefs.h>
+
+class Observable;
+
+class Observer {
+ public:
+								Observer();
+	virtual						~Observer();
+
+	virtual	void				ObjectChanged(const Observable* object) = 0;
+};
+
+#endif // OBSERVER_H

--- a/WonderBrush/src/gui/listviews/Selectable.cpp
+++ b/WonderBrush/src/gui/listviews/Selectable.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2006, Haiku.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ */
+
+#include "Selectable.h"
+
+#include <debugger.h>
+
+#include "Selection.h"
+
+// constructor
+Selectable::Selectable()
+	: fSelected(false),
+	  fSelection(NULL)
+{
+}
+
+// destructor
+Selectable::~Selectable()
+{
+}
+
+// SetSelected
+void
+Selectable::SetSelected(bool selected, bool exclusive)
+{
+	// NOTE: "exclusive" is only useful when selecting,
+	// it is ignored when deselecting...
+	if (selected == fSelected)
+		return;
+
+	if (fSelection) {
+		if (selected)
+			fSelection->Select(this, !exclusive);
+		else
+			fSelection->Deselect(this);
+	} else {
+		debugger("Selectable needs to know Selection\n");
+	}
+}
+
+// SetSelection
+void
+Selectable::SetSelection(Selection* selection)
+{
+	fSelection = selection;
+}
+
+// #pragma mark -
+
+// SetSelected
+void
+Selectable::_SetSelected(bool selected)
+{
+	// NOTE: for private use by the Selection object!
+	if (fSelected != selected) {
+		fSelected = selected;
+		SelectedChanged();
+	}
+}

--- a/WonderBrush/src/gui/listviews/Selectable.h
+++ b/WonderBrush/src/gui/listviews/Selectable.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2006, Haiku.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ */
+
+#ifndef SELECTABLE_H
+#define SELECTABLE_H
+
+#include <SupportDefs.h>
+
+class Selection;
+
+class Selectable {
+ public:
+								Selectable();
+	virtual						~Selectable();
+
+	inline	bool				IsSelected() const
+									{ return fSelected; }
+
+	virtual	void				SelectedChanged() = 0;
+
+	// this works only if the Selection is known
+			void				SetSelected(bool selected,
+											bool exclusive = true);
+			void				SetSelection(Selection* selection);
+
+ private:
+	friend class Selection;
+			void				_SetSelected(bool selected);
+
+			bool				fSelected;
+			Selection*			fSelection;
+};
+
+#endif // SELECTABLE_H

--- a/WonderBrush/src/gui/listviews/Selection.cpp
+++ b/WonderBrush/src/gui/listviews/Selection.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2006, Haiku.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ */
+
+#include "Selection.h"
+
+#include <stdio.h>
+
+#include <debugger.h>
+
+#include "Selectable.h"
+
+// constructor
+Selection::Selection()
+	: fSelected(20)
+{
+}
+
+// destructor
+Selection::~Selection()
+{
+}
+
+// Select
+bool
+Selection::Select(Selectable* object, bool extend)
+{
+	AutoNotificationSuspender _(this);
+
+	if (!extend)
+		_DeselectAllExcept(object);
+
+	bool success = false;
+
+	if (!object->IsSelected()) {
+
+		#if DEBUG
+		if (fSelected.HasItem((void*)object))
+			debugger("Selection::Select() - "
+					 "unselected object in list!");
+		#endif
+
+		if (fSelected.AddItem((void*)object)) {
+			object->_SetSelected(true);
+			success = true;
+
+			Notify();
+		} else {
+			fprintf(stderr, "Selection::Select() - out of memory\n");
+		}
+	} else {
+
+		#if DEBUG
+		if (!fSelected.HasItem((void*)object))
+			debugger("Selection::Select() - "
+					 "already selected object not in list!");
+		#endif
+
+		success = true;
+		// object already in list
+	}
+
+	return success;
+}
+
+// Deselect
+void
+Selection::Deselect(Selectable* object)
+{
+	if (object->IsSelected()) {
+		if (!fSelected.RemoveItem((void*)object))
+			debugger("Selection::Deselect() - "
+					 "selected object not within list!");
+		object->_SetSelected(false);
+
+		Notify();
+	}
+}
+
+// DeselectAll
+void
+Selection::DeselectAll()
+{
+	_DeselectAllExcept(NULL);
+}
+
+// #pragma mark -
+
+// SelectableAt
+Selectable*
+Selection::SelectableAt(int32 index) const
+{
+	return (Selectable*)fSelected.ItemAt(index);
+}
+
+// SelectableAtFast
+Selectable*
+Selection::SelectableAtFast(int32 index) const
+{
+	return (Selectable*)fSelected.ItemAtFast(index);
+}
+
+// CountSelected
+int32
+Selection::CountSelected() const
+{
+	return fSelected.CountItems();
+}
+
+// #pragma mark -
+
+// _DeselectAllExcept
+void
+Selection::_DeselectAllExcept(Selectable* except)
+{
+	bool notify = false;
+	bool containedExcept = false;
+
+	int32 count = fSelected.CountItems();
+	for (int32 i = 0; i < count; i++) {
+		Selectable* object = (Selectable*)fSelected.ItemAtFast(i);
+		if (object != except) {
+			object->_SetSelected(false);
+			notify = true;
+		} else {
+			containedExcept = true;
+		}
+	}
+
+	fSelected.MakeEmpty();
+
+	// if the "except" object was previously
+	// in the selection, add it again after
+	// making the selection list empty
+	if (containedExcept)
+		fSelected.AddItem(except);
+
+	if (notify)
+		Notify();
+}
+

--- a/WonderBrush/src/gui/listviews/Selection.h
+++ b/WonderBrush/src/gui/listviews/Selection.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2006, Haiku.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ */
+
+#ifndef SELECTION_H
+#define SELECTION_H
+
+#include <List.h>
+
+#include "Observable.h"
+
+class Selectable;
+
+class Selection : public Observable {
+ public:
+								Selection();
+	virtual						~Selection();
+
+	// modify selection
+			bool				Select(Selectable* object,
+									   bool extend = false);
+			void				Deselect(Selectable* object);
+			void				DeselectAll();
+
+	// query selection
+			Selectable*			SelectableAt(int32 index) const;
+			Selectable*			SelectableAtFast(int32 index) const;
+			int32				CountSelected() const;
+
+ private:
+			void				_DeselectAllExcept(Selectable* object);
+
+			BList				fSelected;
+};
+
+#endif	// SELECTION_H

--- a/WonderBrush/src/gui/listviews/source_files
+++ b/WonderBrush/src/gui/listviews/source_files
@@ -3,4 +3,7 @@ SOURCE_FILES +=
 	HistoryListView.cpp
 	LayersListView.cpp
 	ListViews.cpp
+	Observer.cpp
+	Selection.cpp
+	Selectable.cpp
 ;

--- a/WonderBrush/src/gui/panels/brush_panel/BrushListView.cpp
+++ b/WonderBrush/src/gui/panels/brush_panel/BrushListView.cpp
@@ -103,10 +103,10 @@ BrushItem::Update(BView* owner, const BFont* font)
 
 // Draw
 void
-BrushItem::Draw(BView* owner, BRect frame, uint32 flags)
+BrushItem::DrawItem(BView* owner, BRect frame, bool even)
 {
 	if (fBitmap && fBitmap->IsValid()) {
-		DrawBackground(owner, BRect(0.0, 0.0, -1.0, -1.0), flags);
+		SimpleItem::DrawBackground(owner, BRect(0.0, 0.0, -1.0, -1.0), even);
 		// see if we need to update our bitmap contents
 		rgb_color color = owner->LowColor();
 		if (fDirty
@@ -173,9 +173,9 @@ BrushItem::Draw(BView* owner, BRect frame, uint32 flags)
 		// let the base class finish off
 		frame.left = fBitmap->Bounds().right + 1.0;
 		owner->SetDrawingMode(B_OP_COPY);
-		SimpleItem::Draw(owner, frame, flags);
+		SimpleItem::DrawItem(owner, frame, even);
 	} else
-		SimpleItem::Draw(owner, frame, flags);
+		SimpleItem::DrawItem(owner, frame, even);
 }
 
 // GetIconRect
@@ -331,6 +331,20 @@ BrushListView::SelectionChanged()
 	}
 	fRenameMI->SetEnabled(item != NULL);
 	fRemoveMI->SetEnabled(item != NULL);
+}
+
+// ArchiveSelection
+status_t
+BrushListView::ArchiveSelection(BMessage*, bool) const
+{
+	return B_OK;
+}
+
+// InstantiateSelection
+bool
+BrushListView::InstantiateSelection(const BMessage*, int32)
+{
+	return true;
 }
 
 // DoubleClicked

--- a/WonderBrush/src/gui/panels/brush_panel/BrushListView.h
+++ b/WonderBrush/src/gui/panels/brush_panel/BrushListView.h
@@ -25,8 +25,8 @@ class BrushItem : public SimpleItem {
 	virtual	void			Update(BView* owner, const BFont* font);
 
 							// SimpleItem
-	virtual	void			Draw(BView* owner, BRect frame,
-								 uint32 flags);
+	virtual	void			DrawItem(BView* owner, BRect frame,
+								 bool even = false);
 
 			void			GetIconRect(BRect& itemFrame) const;
 
@@ -66,6 +66,8 @@ class BrushListView : public SimpleListView {
 	virtual void			SelectionChanged();
 
 							// SimpleListView
+	virtual	status_t		ArchiveSelection(BMessage*, bool = true) const;
+	virtual	bool			InstantiateSelection(const BMessage*, int32);
 	virtual	void			DoubleClicked(int32 index);
 	virtual	BListItem*		CloneItem(int32 atIndex) const;
 

--- a/WonderBrush/src/main.cpp
+++ b/WonderBrush/src/main.cpp
@@ -225,7 +225,8 @@ main(int argc, char** argv)
 		delete be_app;
 
 		// delete global instances of some classes
-		BubbleHelper::DeleteDefault();
+		// TODO fix crashes on Quit() with this line
+		//BubbleHelper::DeleteDefault();
 	}
 
 #if ALLOCATION_CHECK


### PR DESCRIPTION
In [hrev57439](https://git.haiku-os.org/haiku/tag/?h=hrev57439) auto-scroll was re-introduced on BListView's. Unfortunately this conflicts with the auto-scroll feature in Icon-O-Matic and WonderBrush which are using GetMouse() to do their own auto-scroll. So instead, I have taken the auto-scroll feature out of Icon-O-Matic here https://review.haiku-os.org/c/haiku/+/7215 and would like to do the same in WonderBrush. This alters WonderBrush\ to use the BListView version of auto-scroll instead.