### PR TITLE
Fix build with modern gcc

### DIFF
--- a/build/OverriddenJamRules
+++ b/build/OverriddenJamRules
@@ -33,9 +33,17 @@ actions Chmod1
 # headers
 
 if $(OSPLAT) = X86 {
-	HDRS_INCLUDES_SEPARATOR ?= -I- ;
-	HDRS_LOCAL_INCLUDES_OPTION ?= -I ;
-	HDRS_SYSTEM_INCLUDES_OPTION ?= -I ;
+	if $(TARGET_PLATFORM) = haiku64 {
+		HDRS_INCLUDES_SEPARATOR ?= "" ;
+		HDRS_LOCAL_INCLUDES_OPTION ?= "-iquote " ;
+		HDRS_SYSTEM_INCLUDES_OPTION ?= "-isystem " ;
+
+		rule FIncludes { return "-iquote $(<)" ; }
+	} else {
+		HDRS_INCLUDES_SEPARATOR ?= -I- ;
+		HDRS_LOCAL_INCLUDES_OPTION ?= -I ;
+		HDRS_SYSTEM_INCLUDES_OPTION ?= -I ;
+	}
 } else {
 	HDRS_INCLUDES_SEPARATOR ?= -i- ;
 	HDRS_LOCAL_INCLUDES_OPTION ?= -I ;


### PR DESCRIPTION
The -I- option seems broken in current versions of gcc, and prevents searching for includes located in the same directory as the file being processed (which should be the first thing searched).

Note that the option has been deprecated for years, and is kept only because of gcc2 support.

Switch Wonderbrush's jamfiles to use the new -iquote system instead, when compiled on 64-bit Haiku. Unfortunately, just changing the variables defined in the existing Jamfile was not enough, because FInclude is implemented in Jambase and hardcodes -I. So, an extra override for FIncludes is also added, to use -iquote (this is how it is used in Wonderbrush build, with FSysInclude being defined for other includes. Jambase does not have this distinction and just uses -I, which is fine).

I only tested this change on 64bit Haiku.

Fixes #30.